### PR TITLE
chore: extend centralized renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices"
+    "github>pl4nty/.github"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Swaps `config:best-practices` for the centralized preset `github>pl4nty/.github`, which includes it plus `schedule:weekends`, a 7-day `minimumReleaseAge`, and OSV vulnerability alerts. The automerge rule and `gomodTidy` are kept as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsPuqPb9iXJfZUD9QiRkzC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsPuqPb9iXJfZUD9QiRkzC)_